### PR TITLE
Adding in automation with updated documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM google/cloud-sdk:alpine
+
+RUN apk --update add nodejs yarn
+
+ADD . /newbie-go
+
+WORKDIR /newbie-go

--- a/README.md
+++ b/README.md
@@ -37,6 +37,36 @@ To update packages
 yarn upgrade 
 ```
 
+### Working with Docker
+
+To build the container:
+```sh
+docker build -t newbie-go .
+```
+
+Next up we want to start the container in interactive mode as there are a few manual steps that need to happen currently:
+```sh
+docker run -it newbie-go /bin/bash
+```
+
+We have to authenticate against Google with our user account:
+```sh
+gcloud auth login
+```
+You'll need to copy and paste a link into your browser to get a token for authentication. Once that is complete we want to set which project we are using:
+
+```sh
+gcloud config set project sprout-project-6
+```
+
+Finally we can build our app. Unfortunately with how app engine deploys, we need to symlink our build directory into a folder where our `app.yaml` file lives. This is so only files we need are pushed to appengine/cloud storage:
+```sh
+yarn prod:build
+cd gcp
+ln -s /newbie-go/build /newbie-go/gcp/build
+gcloud app deploy
+```
+
 Below are the details related to differnt types of commits
 
 https://github.com/conventional-changelog-archived-repos/conventional-changelog-angular/blob/master/convention.md

--- a/gcp/app.yaml
+++ b/gcp/app.yaml
@@ -1,0 +1,11 @@
+runtime: python27
+api_version: 1
+threadsafe: true
+
+handlers:
+- url: /
+  static_files: build/index.html
+  upload: build/index.html
+
+- url: /
+  static_dir: build


### PR DESCRIPTION
This PR adds the docker and appengine configuration for deploying to GCP.
README file has the instructions added to explain how to authenticate, build and push.